### PR TITLE
Make registration of *new* artifacts succeed

### DIFF
--- a/src/main/scala/com/here/platform/artifact/sbt/resolver/utils/HttpUtils.scala
+++ b/src/main/scala/com/here/platform/artifact/sbt/resolver/utils/HttpUtils.scala
@@ -20,6 +20,7 @@
 package com.here.platform.artifact.sbt.resolver.utils
 
 import java.io.{File, IOException, InputStream}
+import java.net.HttpURLConnection._
 import java.nio.file.{Files, StandardCopyOption}
 
 import org.apache.http.client.methods.{CloseableHttpResponse, HttpGet, HttpPut, HttpUriRequest}
@@ -85,10 +86,13 @@ object HttpUtils {
 
     val statusCode = response.getStatusLine.getStatusCode
     val content = EntityUtils.toString(response.getEntity)
-    if (statusCode == 200) {
-      validatedAndParseRegister(content)
+    statusCode match {
+      case HTTP_OK | HTTP_CREATED => validatedAndParseRegister(content)
+      case _ =>
+        throw RegisterException(
+          if (content.nonEmpty) content
+          else response.getStatusLine.getReasonPhrase)
     }
-    else throw RegisterException(content)
   }
 
   private def validatedAndParseRegister(content: String) = {


### PR DESCRIPTION
Despite successful registrations of *existing* artifacts (when updated),
such turn out to fail for *new* artifacts (when published for the first
time):
```
[info] Uploading here+artifact-service://artifact-service/path/to/my_project_scala_2.12/1.2.3/my_project_scala_2.12-1.2.3.pom
[error] com.here.platform.artifact.sbt.resolver.error.RegisterException
```
... without error message explaining why.

The present change simply consists in:
1. considering HTTP 201 (CREATED) responses as successful. Because they
   are,
2. passing the status line's error message to `RegisterException`
   constructor in lieu of an empty response body data (best effort).