### PR TITLE
Fix `ArtifactUrlConnection`

### DIFF
--- a/src/main/scala/com/here/platform/artifact/sbt/resolver/connection/ArtifactURLConnection.scala
+++ b/src/main/scala/com/here/platform/artifact/sbt/resolver/connection/ArtifactURLConnection.scala
@@ -80,8 +80,8 @@ final class ArtifactURLConnection(url: URL) extends HttpURLConnection(url) {
         }.orNull
       case "last-modified" =>
         response
-          .map {
-            _.getAllHeaders.find(_.getName.equalsIgnoreCase("last-modified")).map(_.getValue).orNull
+          .flatMap {
+            _.getAllHeaders.find(_.getName.equalsIgnoreCase("last-modified")).map(_.getValue)
           }
           .map {
             DateUtils.parseDate

--- a/src/main/scala/com/here/platform/artifact/sbt/resolver/connection/ArtifactURLConnection.scala
+++ b/src/main/scala/com/here/platform/artifact/sbt/resolver/connection/ArtifactURLConnection.scala
@@ -21,7 +21,7 @@ package com.here.platform.artifact.sbt.resolver.connection
 
 import java.io.InputStream
 import java.net.{HttpURLConnection, URL}
-import java.time.ZoneOffset
+import java.time.{Instant, ZoneOffset}
 import java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
 
 import com.here.platform.artifact.sbt.resolver.utils.HttpUtils._
@@ -62,7 +62,8 @@ final class ArtifactURLConnection(url: URL) extends HttpURLConnection(url) {
 
   override def getHeaderField(field: String): String =
     response.getAllHeaders.find(_.getName.equalsIgnoreCase(field)).map(_.getValue).map(v => field.toLowerCase match {
-      case "last-modified" => RFC_1123_DATE_TIME.format(parseDate(v).toInstant.atOffset(ZoneOffset.UTC))
+      case "last-modified" if v.contains("Jan 1970") => // service likely confused milliseconds with seconds
+        RFC_1123_DATE_TIME.format(Instant.ofEpochSecond(parseDate(v).getTime.toInt).atOffset(ZoneOffset.UTC))
       case _ => v
     }).orNull // Should return null if no value for header
 


### PR DESCRIPTION
#### Inline `ArtifactResponse` hierarchy

1. it used to bring an abstraction overhead without a clear reason why:
   all implementation classes were local and consisted of simple
   wrappers of `CloseableHttpResponse` - that already provides an
   acceptable abstraction level,
2. the `GETResponse` implementation class turned out to execute an
   additional `HEAD` request - so _at least_ two requests instead of one
   (1 `HEAD` per access to `metadata`),
3. `ArtifactResponse` used to extend `AutoCloseable` but none of the
   implementation classes turned out to `close` anything,
4. the status line of the wrapped response couldn't be accessed, leading
   to a manually crafted one.

#### Return exact `responseCode` and `responseMessage`

Both used to be manually crafted, disregarding actual: HTTP status code,
reason phrase and protocol version.

This used to cause problems when importing `sbt` projects from within
`IntelliJ IDEA`, or when manually executing `sbt updateClassifiers`:
```
[error] (my-project / updateClassifiers) lmcoursier.internal.shaded.coursier.error.FetchError$DownloadingArtifacts: Error fetching artifacts:
[...]
```

The `HttpURLConnection` parent class happens to set those fields
from the status line, provided the latter is formatted correctly,
which `getHeaderField(0)` now does - thanks to `formatStatusLine`.

#### Fix `IllegalArgumentException: Date value may not be null`
     
One of the consequences of not returning exact HTTP status codes was
that `coursier` was sometimes led to query `Last-Modified` headers of
nonexistent artifacts, hitting a further bug:
```
[error] (my_project / updateClassifiers) lmcoursier.internal.shaded.coursier.error.FetchError$DownloadingArtifacts: Error fetching artifacts:
[error] here+artifact-service://artifact-service/path/to/1.2.3/my_artifact-1.2.3-javadoc.jar: download error: Caught java.lang.IllegalArgumentException: Date value may not be null (Date value may not be null) while downloading here+artifact-service://artifact-service/path/to/my_artifact/1.2.3/my_artifact-1.2.3-javadoc.jar
```

This was because `null` was passed to the `Date` constructor when the
`Last-Modified` header was absent from the response, which the present
commit fixes.

#### Make `response` a `lazy val`

The present commit consists in replacing multiple occurrences of
`if (!connected) connect()` manual constructs by a Scala language
feature: `lazy val`.

This kills two birds with one stone:
1. state is guaranteed to be consistent,
2. code gets simplified by removing one level of indirection.

#### Factor out header field queries
     
This is first to eliminate code duplication.

Moreover, there's no need for filtering out any header field. Quite the
opposite: there might be directives (`Cache-Control`, etc.) the client
should be made aware off.

#### Replace no-op `Last-Modified` rewriting with actual workaround

It turns out that systematically rewriting the `Last-Modified` header
value didn't bring any benefit, for instance:
* in: `Mon, 19 Jan 1970 17:15:56 GMT` (unlikely)
* out: `Mon, 19 Jan 1970 17:15:56 GMT` (same)

Given the service seems to confuse milliseconds with seconds when
computing the `Last-Modified` date, the present change consists in only
rewriting it for unlikely dates in `Jan 1970`, which buys enough time to
get the problem fixed upstream.

The above header value then gets rewritten the following way:
* in: `Mon, 19 Jan 1970 17:15:56 GMT` (unlikely)
* out: `Fri, 2 Apr 2021 09:33:20 GMT` (very likely)