### PR TITLE
Bring back error messages to `sbt` client

### DIFF
--- a/src/main/scala/com/here/platform/artifact/sbt/resolver/error/ArtifactNotFoundException.scala
+++ b/src/main/scala/com/here/platform/artifact/sbt/resolver/error/ArtifactNotFoundException.scala
@@ -19,4 +19,4 @@
 
 package com.here.platform.artifact.sbt.resolver.error
 
-final case class ArtifactNotFoundException() extends RuntimeException
+final case class ArtifactNotFoundException(message: String) extends RuntimeException(message)

--- a/src/main/scala/com/here/platform/artifact/sbt/resolver/error/RegisterException.scala
+++ b/src/main/scala/com/here/platform/artifact/sbt/resolver/error/RegisterException.scala
@@ -19,4 +19,4 @@
 
 package com.here.platform.artifact.sbt.resolver.error
 
-final case class RegisterException(message: String) extends RuntimeException
+final case class RegisterException(message: String) extends RuntimeException(message)

--- a/src/main/scala/com/here/platform/artifact/sbt/resolver/utils/HttpUtils.scala
+++ b/src/main/scala/com/here/platform/artifact/sbt/resolver/utils/HttpUtils.scala
@@ -59,11 +59,9 @@ object HttpUtils {
     val response = executeRequest(httpRequest, Some(contentType))
 
     val statusCode = response.getStatusLine.getStatusCode
-    if (statusCode == 200) {
-      val content = EntityUtils.toString(response.getEntity)
-      validatedAndParseRegister(content)
-    }
-    else throw ArtifactNotFoundException()
+    val content = EntityUtils.toString(response.getEntity)
+    if (statusCode == HTTP_OK) validatedAndParseRegister(content)
+    else throw ArtifactNotFoundException(if (content.nonEmpty) content else response.getStatusLine.getReasonPhrase)
   }
 
   private[artifact] def registerArtifact(groupId: String, artifactId: String): RegisterResponse = {


### PR DESCRIPTION
This is because internal exceptions may be thrown for multiple reasons,
so giving back an error message (even on a best effort basis) is more
enlightening than just the name of the internal exception class:
```
[error]   download error: Caught com.here.platform.artifact.sbt.resolver.error.ArtifactNotFoundException while downloading here+artifact-service://artifact-service/path/to/my-artifact/1.2.3/my-artifact-1.2.3.pom
```

Signed-off-by: Regis Desgroppes <rdesgroppes@users.noreply.github.com>