### PR TITLE
Activate the plugin at an earlier stage

### DIFF
--- a/src/main/scala/com/here/platform/artifact/sbt/resolver/ArtifactResolverPlugin.scala
+++ b/src/main/scala/com/here/platform/artifact/sbt/resolver/ArtifactResolverPlugin.scala
@@ -31,7 +31,7 @@ object ArtifactResolverPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    onLoad in Global := (onLoad in Global).value andThen { state =>
+    onLoad in Global :=  { state: State =>
       def info: String => Unit = state.log.info(_)
 
       def debug: String => Unit = state.log.debug(_)
@@ -72,7 +72,7 @@ object ArtifactResolverPlugin extends AutoPlugin {
       dispatcher.setDownloader("here+artifact-service", new ArtifactURLHandler)
 
       state
-    }
+    } andThen (onLoad in Global).value
   )
 }
 


### PR DESCRIPTION
Right now the plugin takes action in the end of `onLoad` process. 
This makes Here repository not available before sbt config is fully loaded.
For example, one can't refer to Here artifacts in other plugins.
Let's activate the plugin as early as possible.

Signed-off-by: Evgenii Kuznetcov <simpadjo@gmail.com>